### PR TITLE
fix: remediate Flashpoint findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2018-2025 Splunk Inc.
+   Copyright (c) 2018-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Koodous
-Copyright (c) 2018-2025 Splunk Inc.
+Copyright (c) 2018-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/koodous.json
+++ b/koodous.json
@@ -9,7 +9,7 @@
     "product_name": "Koodous",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2018-2025 Splunk Inc.",
+    "license": "Copyright (c) 2018-2026 Splunk Inc.",
     "app_version": "2.1.2",
     "utctime_updated": "2025-09-05T16:38:16.428768Z",
     "package_name": "phantom_koodous",

--- a/koodous_connector.py
+++ b/koodous_connector.py
@@ -94,7 +94,7 @@ class KoodousConnector(BaseConnector):
         )
 
     def _process_html_response(self, response, action_result):
-        if response.status_code:
+        if 200 <= response.status_code < 399:
             return RetVal(phantom.APP_SUCCESS, {})
 
         # An html response, treat it like an error
@@ -282,14 +282,15 @@ class KoodousConnector(BaseConnector):
             data["analysis"] = analysis_response
         action_result.add_data(data)
 
-        if analysis_complete:
-            msg = "Successfully retrieved overview and analysis"
-        else:
-            msg = "Successfully retrieved overview, though no file could be found. Either the {} hasn't been started or is still running".format(
-                "analysis" if analysis_type == "all" else f"{analysis_type} analysis"
+        if not analysis_complete:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                "Polling attempts were exhausted before the {} completed".format(
+                    "analysis" if analysis_type == "all" else f"{analysis_type} analysis"
+                ),
             )
 
-        return action_result.set_status(phantom.APP_SUCCESS, msg)
+        return action_result.set_status(phantom.APP_SUCCESS, "Successfully retrieved overview and analysis")
 
     def _handle_test_connectivity(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))

--- a/koodous_connector.py
+++ b/koodous_connector.py
@@ -173,7 +173,8 @@ class KoodousConnector(BaseConnector):
         if headers is None:
             headers = {}
 
-        headers.update(self._headers)
+        if not ignore_base_url:
+            headers.update(self._headers)
 
         try:
             request_func = getattr(requests, method)

--- a/koodous_connector.py
+++ b/koodous_connector.py
@@ -1,6 +1,6 @@
 # File: koodous_connector.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/koodous_consts.py
+++ b/koodous_consts.py
@@ -1,6 +1,6 @@
 # File: koodous_consts.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
-Limit the Koodous API Authorization header to requests sent to the configured Koodous API origin (PSAAS-30848).
-Return action errors for unsuccessful HTML responses and report polling that exhausts its attempts before analysis completes (PSAAS-32374).
+* Limit the Koodous API Authorization header to requests sent to the configured Koodous API origin (PSAAS-30848).
+* Return action errors for unsuccessful HTML responses and report polling that exhausts its attempts before analysis completes (PSAAS-32374).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 Limit the Koodous API Authorization header to requests sent to the configured Koodous API origin (PSAAS-30848).
+Return action errors for unsuccessful HTML responses and report polling that exhausts its attempts before analysis completes (PSAAS-32374).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+Limit the Koodous API Authorization header to requests sent to the configured Koodous API origin (PSAAS-30848).


### PR DESCRIPTION
## Summary

- keep the Koodous API token off signed cross-origin upload requests
- treat unsuccessful HTML responses as action errors
- fail report retrieval when its polling budget expires before analysis completes
- update connector tooling to dev-cicd-tools v2.2.4 and refresh generated artifacts

## Tracking

- [PAPP-38223](https://splunk.atlassian.net/browse/PAPP-38223)
- [PSAAS-30848](https://splunk.atlassian.net/browse/PSAAS-30848) (VULN-93573 / FS-1661)
- [PSAAS-32374](https://splunk.atlassian.net/browse/PSAAS-32374) (VULN-95097 / FS-3620)

## Validation

- `pre-commit run --all-files`

The upload-URL recommendation was adapted because Koodous signed upload URLs may legitimately use another origin: the connector preserves that flow but no longer forwards the Koodous Authorization header to it. This pull request was written by Codex with AI assistance.